### PR TITLE
Ruby improvements

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -140,15 +140,12 @@ function colorRuby(x: Parser.SyntaxNode, editor: vscode.TextEditor) {
 			colors.push([x.children[3], 'entity.name.function'])
 		} else if (variables.includes(x.type)) {
 			colors.push([x, 'variable'])
-		} else if (x.type == 'call' && x.lastChild!.type == 'identifier') {
-			colors.push([x.lastChild!, 'entity.name.function'])
-		// Method parameters
-		} else if (x.type == 'identifier' && x.parent!.type == 'method_parameters') {
-			colors.push([x, 'variable.parameter'])
-		} else if (x.type == 'method_call' && x.firstChild!.type == 'identifier') {
-			colors.push([x.firstChild!, 'entity.name.function'])
+		} else if (x.type == 'call' && x.lastChild && x.lastChild.type == 'identifier') {
+			colors.push([x.lastChild, 'entity.name.function'])
+		} else if (x.type == 'method_call' && x.firstChild && x.firstChild.type == 'identifier') {
+			colors.push([x.firstChild, 'entity.name.function'])
 		} else if (x.type == 'end') {
-			if (control.includes(x.parent!.type)) {
+			if (x.parent && control.includes(x.parent.type)) {
 				colors.push([x, 'keyword.control'])
 			} else {
 				colors.push([x, 'keyword'])
@@ -157,6 +154,9 @@ function colorRuby(x: Parser.SyntaxNode, editor: vscode.TextEditor) {
 			colors.push([x, 'entity.name.type'])
 		} else if (x.type == 'symbol') {
 			colors.push([x, 'constant.language'])
+		// Method parameters
+		} else if (x.type == 'identifier' && x.parent && x.parent.type == 'method_parameters') {
+			colors.push([x, 'variable.parameter'])
 		}
 		for (const child of x.children) {
 			scan(child)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -153,7 +153,7 @@ function colorRuby(x: Parser.SyntaxNode, editor: vscode.TextEditor) {
 		} else if (x.type == 'constant') {
 			colors.push([x, 'entity.name.type'])
 		} else if (x.type == 'symbol') {
-			colors.push([x, 'constant.numeric'])
+			colors.push([x, 'constant.language'])
 		}
 		for (const child of x.children) {
 			scan(child)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,6 +142,9 @@ function colorRuby(x: Parser.SyntaxNode, editor: vscode.TextEditor) {
 			colors.push([x, 'variable'])
 		} else if (x.type == 'call' && x.lastChild!.type == 'identifier') {
 			colors.push([x.lastChild!, 'entity.name.function'])
+		// Method parameters
+		} else if (x.type == 'identifier' && x.parent!.type == 'method_parameters') {
+			colors.push([x, 'variable.parameter'])
 		} else if (x.type == 'method_call' && x.firstChild!.type == 'identifier') {
 			colors.push([x.firstChild!, 'entity.name.function'])
 		} else if (x.type == 'end') {

--- a/textmate/ruby.tmLanguage.json
+++ b/textmate/ruby.tmLanguage.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
     "name": "Ruby",
     "scopeName": "source.ruby",
     "patterns": [
@@ -16,8 +16,12 @@
             "name": "keyword.control.ruby"
         },
         {
+            "match": "\\b(initialize|new|loop|include|extend|prepend|raise|fail|attr_reader|attr_writer|attr_accessor|attr|catch|throw|private|private_class_method|module_function|public|public_class_method|protected|refine|using)\\b(?![?!])",
+            "name": "keyword.other.special-method.ruby"
+        },
+        {
             "match": "\\b(false|nil|true)\\b",
-			"name": "constant.numeric.language.ruby"
+            "name": "constant.numeric.language.ruby"
         },
         {
             "match":


### PR DESCRIPTION
This resolves some issues I pointed out in #12.

### Ruby method parameters

Before
<img width="535" alt="Screen Shot 2019-05-26 at 4 46 09 PM" src="https://user-images.githubusercontent.com/2977353/58388005-ca482c80-7fd5-11e9-8204-82896c86e3bd.png">

After
<img width="540" alt="Screen Shot 2019-05-26 at 4 45 49 PM" src="https://user-images.githubusercontent.com/2977353/58388002-bc92a700-7fd5-11e9-9363-2259e8a5c8a6.png">

### Ruby keywords

This doesn't quite catch everything because the method catchers are a bit too aggressive (e.g. `attr_reader :variable_name` should have `attr_reader` caught as a keyword but is not), will need to fix that later.

Before
<img width="573" alt="Screen Shot 2019-05-26 at 4 46 50 PM" src="https://user-images.githubusercontent.com/2977353/58388013-eb108200-7fd5-11e9-82d1-a4986d4265b4.png">

After
<img width="574" alt="Screen Shot 2019-05-26 at 4 47 03 PM" src="https://user-images.githubusercontent.com/2977353/58388014-eba91880-7fd5-11e9-8fe0-9d41eb884e24.png">

### Changed symbols from `constant.numeric` to `constant.language`

Before
<img width="614" alt="Screen Shot 2019-05-26 at 4 49 01 PM" src="https://user-images.githubusercontent.com/2977353/58388035-3591fe80-7fd6-11e9-944f-6ec8bdd4d973.png">

After
<img width="604" alt="Screen Shot 2019-05-26 at 4 49 08 PM" src="https://user-images.githubusercontent.com/2977353/58388036-3591fe80-7fd6-11e9-832a-5676b1e0233c.png">