### PR TITLE
Set extensionKind to "ui"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"url": "https://github.com/georgewfraser/vscode-tree-sitter"
 	},
 	"license": "MIT",
+	"extensionKind": "ui",
 	"engines": {
 		"vscode": "^1.34.0"
 	},


### PR DESCRIPTION
Fixes #23

Admittedly not tested, but changing extensionKind via `settings.json` works.