### PR TITLE
Merge theme with "editor.tokenColorCustomizations" 

### DIFF
--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -77,15 +77,38 @@ async function loadThemeFile(themePath: string) {
     }
 }
 
+function mergeRuleSettings(defaultRule: TextMateRuleSettings, override: TextMateRuleSettings): TextMateRuleSettings {
+    const mergedRule = defaultRule;
+    if (override.background) {
+        mergedRule.background = override.background
+    }
+    if (override.foreground) {
+        mergedRule.foreground = override.foreground
+    }
+    if (override.background) {
+        mergedRule.fontStyle = override.fontStyle
+    }
+    return mergedRule;
+}
+
 function loadColors(textMateRules: TextMateRule[]): void {
     for (const rule of textMateRules) {
-        if (typeof rule.scope == 'string') {
-            if (!colors.has(rule.scope)) {
+
+        if (typeof rule.scope === 'string') {
+            const existingRule = colors.get(rule.scope);
+            if (existingRule) {
+                colors.set(rule.scope, mergeRuleSettings(existingRule, rule.settings))
+            }
+            else {
                 colors.set(rule.scope, rule.settings)
             }
         } else if (rule.scope instanceof Array) {
             for (const scope of rule.scope) {
-                if (!colors.has(scope)) {
+                const existingRule = colors.get(scope);
+                if (existingRule) {
+                    colors.set(scope, mergeRuleSettings(existingRule, rule.settings))
+                }
+                else {
                     colors.set(scope, rule.settings)
                 }
             }

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -60,6 +60,11 @@ async function loadThemeNamed(themeName: string) {
             }
         }
     }
+    
+    const customization: any = vscode.workspace.getConfiguration('editor').get('tokenColorCustomizations');
+    if (customization && customization.textMateRules) {
+	loadColors(customization.textMateRules)
+    }
 }
 
 async function loadThemeFile(themePath: string) {

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -82,19 +82,16 @@ async function loadThemeFile(themePath: string) {
     }
 }
 
-function mergeRuleSettings(defaultRule: TextMateRuleSettings, override: TextMateRuleSettings): TextMateRuleSettings {
-    const mergedRule = defaultRule;
-    if (override.background) {
-        mergedRule.background = override.background
-    }
-    if (override.foreground) {
-        mergedRule.foreground = override.foreground
-    }
-    if (override.background) {
-        mergedRule.fontStyle = override.fontStyle
-    }
+function mergeRuleSettings(defaultSetting: TextMateRuleSettings, override: TextMateRuleSettings): TextMateRuleSettings {
+    const mergedRule = defaultSetting;
+
+    mergedRule.background = override.background || defaultSetting.background
+    mergedRule.foreground = override.foreground || defaultSetting.foreground
+    mergedRule.fontStyle = override.fontStyle || defaultSetting.foreground;
+
     return mergedRule;
 }
+
 
 function loadColors(textMateRules: TextMateRule[]): void {
     for (const rule of textMateRules) {

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -40,7 +40,7 @@ export async function load() {
 }
 
 // Find current theme on disk
-async function function loadThemeNamed(themeName: string) {
+async function loadThemeNamed(themeName: string) {
 
      const themePaths = vscode.extensions.all
          .filter(extension => extension.extensionKind === vscode.ExtensionKind.UI)


### PR DESCRIPTION
Technically it only merges with `"editor.tokenColorCustomizations.textMateRules"` but that's a good start. 
It only merges if the override has a value set so we don't remove anything. 

Edit: Would be nice to have `scopes.ts` as its own package. 