### PR TITLE
fixed incorrect directory name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ You are also welcome to fix the problem yourself and submit a PR. Colorization i
 It's straightforward to add any [language with a tree-sitter grammar](https://tree-sitter.github.io/tree-sitter/).
 
 1. Add a dependency on the npm package for that language: `npm install tree-sitter-yourlang`.
-2. Add a color function to `./lib/colors.ts`
-3. Add a language to the dictionary at the top of `./lib/extension.ts`
+2. Add a color function to `./src/colors.ts`
+3. Add a language to the dictionary at the top of `./src/extension.ts`
 4. Add a **simplified** TextMate grammar to `./textmate/yourlang.tmLanguage.json`. The job of this textmate grammar is just to color keywords and simple literals; anything tricky should be left white and colored by your color function.
 5. Add a reference to the grammar to the [contributes.grammars section of package.json](https://github.com/georgewfraser/vscode-tree-sitter/blob/fb4400b78481845c6a8497d079508d28aea25c19/package.json#L26). `yourlang` must be a [VSCode language identifier](https://code.visualstudio.com/docs/languages/identifiers).
 6. Add a reference to `onLanguage:yourlang` to the [activationEvents section of package.json](https://github.com/georgewfraser/vscode-tree-sitter/blob/fb4400b78481845c6a8497d079508d28aea25c19/package.json#L18). `yourlang` must be a [VSCode language identifier](https://code.visualstudio.com/docs/languages/identifiers).


### PR DESCRIPTION
line 41 and 42: the paths should be `./src/colors.ts` and `./src/extension.ts` according to the source 
but they read `./lib/colors/ts` and `./lib/extension.ts` instead